### PR TITLE
Update tests to pass

### DIFF
--- a/test/functions/lydia/genericActualTypeArg.good
+++ b/test/functions/lydia/genericActualTypeArg.good
@@ -1,2 +1,2 @@
-genericActualTypeArg.chpl:6: error: the type of the actual argument 'Foo' is generic
-note: generic actual arguments are not currently supported
+int(64)
+borrowed Foo

--- a/test/functions/lydia/genericActualTypeArg2.good
+++ b/test/functions/lydia/genericActualTypeArg2.good
@@ -1,2 +1,1 @@
-genericActualTypeArg2.chpl:2: error: the type of the actual argument 'Foo' is generic
-note: generic actual arguments are not currently supported
+borrowed Foo

--- a/test/functions/lydia/genericActualTypeArg3.good
+++ b/test/functions/lydia/genericActualTypeArg3.good
@@ -1,2 +1,1 @@
-genericActualTypeArg3.chpl:2: error: the type of the actual argument 'Foo' is generic
-note: generic actual arguments are not currently supported
+borrowed Foo

--- a/test/types/records/vass/issue-11846-b.good
+++ b/test/types/records/vass/issue-11846-b.good
@@ -1,2 +1,1 @@
-issue-11846-b.chpl:7: error: the type of the actual argument 'R3' is generic
-note: generic actual arguments are not currently supported
+issue-11846-b.chpl:5: error: unable to resolve type


### PR DESCRIPTION
genericActualTypeArg* now function (which is expected)
issue-11846-b still fails but with a different error