### PR TITLE
add (de)serialize methods for all remaining uAST nodes

### DIFF
--- a/compiler/parser/parser.cpp
+++ b/compiler/parser/parser.cpp
@@ -946,11 +946,12 @@ static ModuleSymbol* dynoParseFile(const char* fileName,
     auto res = chpl::uast::BuilderResult::deserializeFromFile(gContext, ss);
 
     if (builderResult.compare(res) == false) {
-      printf("FAIL: %s\n", builderResult.filePath().c_str());
-    } else {
-      printf("SUCCESS: %s\n", builderResult.filePath().c_str());
+      //printf("FAIL: %s\n", builderResult.filePath().c_str());
+      USR_FATAL("FAILED TO (DE)SERIALIZE %s\n", builderResult.filePath().c_str());
+//    } else {
+      //printf("SUCCESS: %s\n", builderResult.filePath().c_str());
     }
-    builderResult.printNumNodes();
+//    builderResult.printNumNodes();
   }
 
   ModuleSymbol* lastModSym = nullptr;

--- a/doc/util/nitpick_ignore
+++ b/doc/util/nitpick_ignore
@@ -56,3 +56,5 @@ cpp:identifier uast::asttags::NUM_AST_TAGS
 cpp:identifier uast::Function::DEFAULT_RETURN_INTENT
 # Common symbols used as template typenames.
 cpp:identifier T
+cpp:identifier Deserializer
+cpp:identifier Serializer

--- a/frontend/include/chpl/uast/AnonFormal.h
+++ b/frontend/include/chpl/uast/AnonFormal.h
@@ -77,6 +77,11 @@ class AnonFormal final : public AstNode {
       typeExpressionChildNum_(typeExpressionChildNum) {
   }
 
+  AnonFormal(Deserializer& des)
+    : AstNode(asttags::AnonFormal, des) {
+      intent_ = des.read<Formal::Intent>();
+    }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const AnonFormal* lhs = this;
     const AnonFormal* rhs = (const AnonFormal*) other;
@@ -113,10 +118,23 @@ class AnonFormal final : public AstNode {
   static std::string intentToString(Intent intent) {
     return Formal::intentToString(intent);
   }
+
+  void serialize(Serializer& ser) const override {
+    AstNode::serializePart(ser);
+    ser(intent_);
+  }
+
+  DECLARE_STATIC_DES(AnonFormal);
+
 };
 
 
 } // end namespace uast
+
+
+DECLARE_SERDE_ENUM(uast::Formal::Intent, uint8_t);
+
+
 } // end namespace chpl
 
 #endif

--- a/frontend/include/chpl/uast/Array.h
+++ b/frontend/include/chpl/uast/Array.h
@@ -47,6 +47,10 @@ class Array final : public AstNode {
     : AstNode(asttags::Array, std::move(children)) {
   }
 
+  Array(Deserializer& des)
+    : AstNode(asttags::Array, des) {
+  }
+
   bool contentsMatchInner(const AstNode* other) const override {
     return true;
   }
@@ -85,6 +89,12 @@ class Array final : public AstNode {
     const AstNode* ast = this->child(i);
     return ast;
   }
+
+  void serialize(Serializer& ser) const override {
+    AstNode::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(Array);
 
 };
 

--- a/frontend/include/chpl/uast/Begin.h
+++ b/frontend/include/chpl/uast/Begin.h
@@ -56,6 +56,11 @@ class Begin final : public SimpleBlockLike {
       withClauseChildNum_(withClauseChildNum) {
   }
 
+    Begin(Deserializer& des)
+    : SimpleBlockLike(asttags::Begin, des) {
+      withClauseChildNum_ = des.read<int8_t>();
+    }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const Begin* lhs = this;
     const Begin* rhs = (const Begin*) other;
@@ -95,6 +100,13 @@ class Begin final : public SimpleBlockLike {
     assert(ret->isWithClause());
     return (const WithClause*)ret;
   }
+
+  void serialize(Serializer& ser) const override {
+    SimpleBlockLike::serializePart(ser);
+    ser(withClauseChildNum_);
+  }
+
+  DECLARE_STATIC_DES(Begin);
 
 };
 

--- a/frontend/include/chpl/uast/Break.h
+++ b/frontend/include/chpl/uast/Break.h
@@ -48,6 +48,11 @@ class Break : public AstNode {
     assert(numChildren() <= 1);
   }
 
+  Break(Deserializer& des)
+   : AstNode(asttags::Break, des) {
+    targetChildNum_ = des.read<int8_t>();
+    }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const Break* lhs = this;
     const Break* rhs = other->toBreak();
@@ -81,6 +86,13 @@ class Break : public AstNode {
     assert(ret->isIdentifier());
     return (const Identifier*)ret;
   }
+
+  void serialize(Serializer& ser) const override {
+    AstNode::serializePart(ser);
+    ser(targetChildNum_);
+  }
+
+  DECLARE_STATIC_DES(Break);
 
 };
 

--- a/frontend/include/chpl/uast/Catch.h
+++ b/frontend/include/chpl/uast/Catch.h
@@ -54,6 +54,13 @@ class Catch final : public AstNode {
       hasParensAroundError_(hasParensAroundError) {
   }
 
+  Catch(Deserializer& des)
+    : AstNode(asttags::Catch, des) {
+        errorChildNum_ = des.read<int8_t>();
+        bodyChildNum_ = des.read<int8_t>();
+        hasParensAroundError_ = des.read<bool>();
+      }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const Catch* rhs = other->toCatch();
     return this->errorChildNum_ == rhs->errorChildNum_ &&
@@ -126,6 +133,15 @@ class Catch final : public AstNode {
   bool hasParensAroundError() const {
     return hasParensAroundError_;
   }
+
+  void serialize(Serializer& ser) const override {
+    AstNode::serializePart(ser);
+    ser(errorChildNum_);
+    ser(bodyChildNum_);
+    ser(hasParensAroundError_);
+  }
+
+  DECLARE_STATIC_DES(Catch);
 
 };
 

--- a/frontend/include/chpl/uast/Class.h
+++ b/frontend/include/chpl/uast/Class.h
@@ -65,7 +65,9 @@ class Class final : public AggregateDecl {
   }
 
   Class(Deserializer& des)
-    : AggregateDecl(asttags::Class, des) { }
+    : AggregateDecl(asttags::Class, des) {
+      parentClassChildNum_ = des.read<int>();
+     }
 
   bool contentsMatchInner(const AstNode* other) const override {
     const Class* lhs = this;
@@ -102,6 +104,7 @@ class Class final : public AggregateDecl {
 
   void serialize(Serializer& ser) const override {
     AggregateDecl::serializePart(ser);
+    ser(parentClassChildNum_);
   }
 
   DECLARE_STATIC_DES(Class);

--- a/frontend/include/chpl/uast/Class.h
+++ b/frontend/include/chpl/uast/Class.h
@@ -64,6 +64,9 @@ class Class final : public AggregateDecl {
            child(parentClassChildNum_)->isIdentifier());
   }
 
+  Class(Deserializer& des)
+    : AggregateDecl(asttags::Class, des) { }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const Class* lhs = this;
     const Class* rhs = (const Class*) other;
@@ -96,6 +99,13 @@ class Class final : public AggregateDecl {
     auto ret = child(parentClassChildNum_);
     return ret;
   }
+
+  void serialize(Serializer& ser) const override {
+    AggregateDecl::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(Class);
+
 };
 
 

--- a/frontend/include/chpl/uast/Cobegin.h
+++ b/frontend/include/chpl/uast/Cobegin.h
@@ -55,6 +55,12 @@ class Cobegin final : public AstNode {
       numTaskBodies_(numTaskBodies) {
   }
 
+  Cobegin(Deserializer& des) : AstNode(asttags::Cobegin, des) {
+    withClauseChildNum_ = des.read<int8_t>();
+    bodyChildNum_ = des.read<int>();
+    numTaskBodies_ = des.read<int>();
+  }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const Cobegin* lhs = this;
     const Cobegin* rhs = (const Cobegin*) other;
@@ -122,6 +128,12 @@ class Cobegin final : public AstNode {
     const AstNode* ast = this->child(i + bodyChildNum_);
     return ast;
   }
+
+  void serialize(Serializer& ser) const override {
+    AstNode::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(Cobegin);
 
 };
 

--- a/frontend/include/chpl/uast/Cobegin.h
+++ b/frontend/include/chpl/uast/Cobegin.h
@@ -131,6 +131,9 @@ class Cobegin final : public AstNode {
 
   void serialize(Serializer& ser) const override {
     AstNode::serializePart(ser);
+    ser(withClauseChildNum_ );
+    ser(bodyChildNum_);
+    ser(numTaskBodies_);
   }
 
   DECLARE_STATIC_DES(Cobegin);

--- a/frontend/include/chpl/uast/Coforall.h
+++ b/frontend/include/chpl/uast/Coforall.h
@@ -59,6 +59,8 @@ class Coforall final : public IndexableLoop {
                     /*isExpressionLevel*/ false) {
   }
 
+  Coforall(Deserializer& des) : IndexableLoop(asttags::Coforall, des) { }
+
   bool contentsMatchInner(const AstNode* other) const override {
     return indexableLoopContentsMatchInner(other->toIndexableLoop());
   }
@@ -80,6 +82,11 @@ class Coforall final : public IndexableLoop {
                                BlockStyle blockStyle,
                                owned<Block> body);
 
+  void serialize(Serializer& ser) const override {
+    IndexableLoop::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(Coforall);
 
 };
 

--- a/frontend/include/chpl/uast/Continue.h
+++ b/frontend/include/chpl/uast/Continue.h
@@ -87,7 +87,7 @@ class Continue : public AstNode {
   }
 
   void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
+    AstNode::serializePart(ser);
     ser(targetChildNum_);
   }
 

--- a/frontend/include/chpl/uast/Continue.h
+++ b/frontend/include/chpl/uast/Continue.h
@@ -47,6 +47,11 @@ class Continue : public AstNode {
     assert(numChildren() <= 1);
   }
 
+  Continue(Deserializer& des)
+    : AstNode(asttags::Continue, des) {
+    targetChildNum_ = des.read<int8_t>();
+  }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const Continue* lhs = this;
     const Continue* rhs = other->toContinue();
@@ -80,6 +85,13 @@ class Continue : public AstNode {
     assert(ret->isIdentifier());
     return (const Identifier*)ret;
   }
+
+  void serialize(Serializer& ser) const override {
+    AstNode::serialize(ser);
+    ser(targetChildNum_);
+  }
+
+  DECLARE_STATIC_DES(Continue);
 
 };
 

--- a/frontend/include/chpl/uast/Defer.h
+++ b/frontend/include/chpl/uast/Defer.h
@@ -57,6 +57,9 @@ class Defer final : public SimpleBlockLike {
     assert(bodyChildNum_ >= 0);
   }
 
+  Defer(Deserializer& des)
+  : SimpleBlockLike(asttags::Defer, des) {}
+
   bool contentsMatchInner(const AstNode* other) const override {
     return simpleBlockLikeContentsMatchInner(other);
   }
@@ -74,6 +77,12 @@ class Defer final : public SimpleBlockLike {
   static owned<Defer> build(Builder* builder, Location loc,
                             BlockStyle blockStyle,
                             AstList stmts);
+
+  void serialize(Serializer& ser) const override {
+    SimpleBlockLike::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(Defer);
 
 };
 

--- a/frontend/include/chpl/uast/Delete.h
+++ b/frontend/include/chpl/uast/Delete.h
@@ -45,6 +45,9 @@ class Delete final : public AstNode {
     : AstNode(asttags::Delete, std::move(children)) {
   }
 
+  Delete(Deserializer& des)
+    : AstNode(asttags::Delete, des) {}
+
   bool contentsMatchInner(const AstNode* other) const override {
     return true;
   }
@@ -82,6 +85,14 @@ class Delete final : public AstNode {
     const AstNode* ast = this->child(i);
     return ast;
   }
+
+  void serialize(Serializer& ser) const override {
+    AstNode::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(Delete);
+
+
 };
 
 

--- a/frontend/include/chpl/uast/DoWhile.h
+++ b/frontend/include/chpl/uast/DoWhile.h
@@ -56,6 +56,11 @@ class DoWhile final : public Loop {
     assert(condition());
   }
 
+  DoWhile(Deserializer& des)
+    : Loop(asttags::DoWhile, des) {
+      conditionChildNum_ = des.read<int>();
+    }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const DoWhile* lhs = this;
     const DoWhile* rhs = (const DoWhile*) other;
@@ -94,6 +99,13 @@ class DoWhile final : public Loop {
     auto ret = child(conditionChildNum_);
     return ret;
   }
+
+  void serialize(Serializer& ser) const override {
+    Loop::serializePart(ser);
+    ser(conditionChildNum_);
+  }
+
+  DECLARE_STATIC_DES(DoWhile);
 
 };
 

--- a/frontend/include/chpl/uast/Enum.h
+++ b/frontend/include/chpl/uast/Enum.h
@@ -63,6 +63,9 @@ class Enum final : public TypeDecl {
     #endif
   }
 
+  Enum(Deserializer& des)
+    : TypeDecl(asttags::Enum, des) {}
+
   int declOrCommentChildNum() const {
     return attributes() ? 1 : 0;
   }
@@ -123,6 +126,13 @@ class Enum final : public TypeDecl {
     auto end = begin + numDeclOrComments();
     return AstListNoCommentsIteratorPair<EnumElement>(begin, end);
   }
+
+  void serialize(Serializer& ser) const override {
+    TypeDecl::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(Enum);
+
 };
 
 

--- a/frontend/include/chpl/uast/EnumElement.h
+++ b/frontend/include/chpl/uast/EnumElement.h
@@ -53,6 +53,9 @@ class EnumElement final : public NamedDecl {
     assert(children_.size() <= 2);
   }
 
+  EnumElement(Deserializer& des)
+    : NamedDecl(asttags::EnumElement, des) {}
+
   bool contentsMatchInner(const AstNode* other) const override {
     const EnumElement* lhs = (const EnumElement*) this;
     const EnumElement* rhs = (const EnumElement*) other;
@@ -102,6 +105,13 @@ class EnumElement final : public NamedDecl {
       return nullptr;
     }
   }
+
+  void serialize(Serializer& ser) const override {
+    NamedDecl::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(EnumElement);
+
 };
 
 

--- a/frontend/include/chpl/uast/ErroneousExpression.h
+++ b/frontend/include/chpl/uast/ErroneousExpression.h
@@ -35,6 +35,11 @@ class ErroneousExpression final : public AstNode {
   ErroneousExpression()
     : AstNode(asttags::ErroneousExpression) {
   }
+
+  ErroneousExpression(Deserializer& des)
+    : AstNode(asttags::ErroneousExpression, des) {}
+
+
   bool contentsMatchInner(const AstNode* other) const override {
     return true;
   }
@@ -44,6 +49,13 @@ class ErroneousExpression final : public AstNode {
  public:
   ~ErroneousExpression() = default;
   static owned<ErroneousExpression> build(Builder* builder, Location loc);
+
+  void serialize(Serializer& ser) const override {
+    AstNode::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(ErroneousExpression);
+
 };
 
 

--- a/frontend/include/chpl/uast/ExternBlock.h
+++ b/frontend/include/chpl/uast/ExternBlock.h
@@ -55,6 +55,11 @@ class ExternBlock final : public AstNode {
     assert(numChildren() == 0);
   }
 
+  ExternBlock(Deserializer& des)
+    : AstNode(asttags::ExternBlock, des) {
+      code_ = des.read<std::string>();
+    }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const ExternBlock* rhs = (const ExternBlock*)other;
     return this->code_ == rhs->code_;
@@ -74,6 +79,11 @@ class ExternBlock final : public AstNode {
 
   const std::string& code() const {
     return code_;
+  }
+
+  void serialize(Serializer& ser) const override {
+    AstNode::serializePart(ser);
+    ser(code_);
   }
 
 };

--- a/frontend/include/chpl/uast/ExternBlock.h
+++ b/frontend/include/chpl/uast/ExternBlock.h
@@ -86,6 +86,8 @@ class ExternBlock final : public AstNode {
     ser(code_);
   }
 
+  DECLARE_STATIC_DES(ExternBlock);
+
 };
 
 

--- a/frontend/include/chpl/uast/Forall.h
+++ b/frontend/include/chpl/uast/Forall.h
@@ -61,6 +61,10 @@ class Forall final : public IndexableLoop {
                     isExpressionLevel) {
   }
 
+  Forall(Deserializer& des)
+    : IndexableLoop(asttags::Forall, des) {
+  }
+
   bool contentsMatchInner(const AstNode* other) const override {
     return indexableLoopContentsMatchInner(other->toIndexableLoop());
   }
@@ -82,6 +86,12 @@ class Forall final : public IndexableLoop {
                              BlockStyle blockStyle,
                              owned<Block> body,
                              bool isExpressionLevel);
+
+  void serialize(Serializer& ser) const override {
+    IndexableLoop::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(Forall);
 
 };
 

--- a/frontend/include/chpl/uast/Foreach.h
+++ b/frontend/include/chpl/uast/Foreach.h
@@ -61,6 +61,9 @@ class Foreach final : public IndexableLoop {
 
   }
 
+  Foreach(Deserializer& des)
+    : IndexableLoop(asttags::Foreach, des) {}
+
   bool contentsMatchInner(const AstNode* other) const override {
     return indexableLoopContentsMatchInner(other->toIndexableLoop());
   }
@@ -82,6 +85,12 @@ class Foreach final : public IndexableLoop {
                               BlockStyle blockStyle,
                               owned<Block> body);
 
+
+  void serialize(Serializer& ser) const override {
+    IndexableLoop::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(Foreach);
 
 };
 

--- a/frontend/include/chpl/uast/ForwardingDecl.h
+++ b/frontend/include/chpl/uast/ForwardingDecl.h
@@ -69,6 +69,9 @@ private:
     assert(children_.size() >= 0 && children_.size() <= 2);
   }
 
+  ForwardingDecl(Deserializer& des)
+    : Decl(asttags::ForwardingDecl, des) { }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const ForwardingDecl* lhs = (const ForwardingDecl*) this;
     const ForwardingDecl* rhs = (const ForwardingDecl*) other;
@@ -107,6 +110,13 @@ private:
       return nullptr;
     }
   }
+
+  void serialize(Serializer& ser) const override {
+    Decl::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(ForwardingDecl);
+
 };
 
 

--- a/frontend/include/chpl/uast/FunctionSignature.h
+++ b/frontend/include/chpl/uast/FunctionSignature.h
@@ -86,6 +86,18 @@ class FunctionSignature final : public AstNode {
                  returnTypeChildNum_ < (ssize_t)children_.size());
   }
 
+  FunctionSignature(Deserializer& des)
+    : AstNode(asttags::FunctionSignature, des) {
+      kind_ = des.read<Kind>();
+      returnIntent_ = des.read<ReturnIntent>();
+      formalsChildNum_ = des.read<int>();
+      thisFormalChildNum_ = des.read<int>();
+      numFormals_= des.read<int>();
+      returnTypeChildNum_ = des.read<int>();
+      throws_ = des.read<bool>();
+      isParenless_ = des.read<bool>();
+    }
+
   bool contentsMatchInner(const AstNode* other) const override {
     auto lhs = this;
     auto rhs = (const FunctionSignature*) other;
@@ -159,6 +171,20 @@ class FunctionSignature final : public AstNode {
     const AstNode* ret = this->child(returnTypeChildNum_);
     return ret;
   }
+
+  void serialize(Serializer& ser) const override {
+    AstNode::serializePart(ser);
+    ser(kind_);
+    ser(returnIntent_);
+    ser(formalsChildNum_);
+    ser(thisFormalChildNum_);
+    ser(numFormals_);
+    ser(returnTypeChildNum_);
+    ser(throws_);
+    ser(isParenless_);
+  }
+
+  DECLARE_STATIC_DES(FunctionSignature);
 
 };
 

--- a/frontend/include/chpl/uast/Implements.h
+++ b/frontend/include/chpl/uast/Implements.h
@@ -78,6 +78,11 @@ class Implements final : public AstNode {
            interfaceExpr()->isFnCall());
   }
 
+  Implements(Deserializer& des)
+    : AstNode(asttags::Implements, des) {
+      typeIdentChildNum_ = des.read<int8_t>();
+      isExpressionLevel_ = des.read<bool>();
+    }
   bool contentsMatchInner(const AstNode* other) const override {
     const Implements* lhs = this;
     const Implements* rhs = (const Implements*) other;
@@ -164,6 +169,15 @@ class Implements final : public AstNode {
                                  owned<Identifier> typeIdent,
                                  owned<AstNode> interfaceExpr,
                                  bool isExpressionLevel);
+
+  void serialize(Serializer& ser) const override {
+    AstNode::serializePart(ser);
+    ser(typeIdentChildNum_);
+    ser(isExpressionLevel_);
+  }
+
+  DECLARE_STATIC_DES(Implements);
+
 };
 
 

--- a/frontend/include/chpl/uast/Import.h
+++ b/frontend/include/chpl/uast/Import.h
@@ -59,6 +59,10 @@ class Import final : public AstNode {
     #endif
   }
 
+  Import(Deserializer& des)
+    : AstNode(asttags::Import, des)
+      {visibility_=des.read<Decl::Visibility>();}
+
   bool contentsMatchInner(const AstNode* other) const override {
     const Import* rhs = other->toImport();
     return this->visibility_ == rhs->visibility_;
@@ -108,6 +112,13 @@ class Import final : public AstNode {
     assert(ret->isVisibilityClause());
     return (const VisibilityClause*)ret;
   }
+
+  void serialize(Serializer& ser) const override {
+    AstNode::serializePart(ser);
+    ser(visibility_);
+  }
+
+  DECLARE_STATIC_DES(Import);
 
 };
 

--- a/frontend/include/chpl/uast/Include.h
+++ b/frontend/include/chpl/uast/Include.h
@@ -58,6 +58,14 @@ class Include final : public AstNode {
     assert(!name_.isEmpty());
   }
 
+  Include(Deserializer& des)
+    : AstNode(asttags::Include, des) {
+      visibility_ = des.read<Decl::Visibility>();
+      isPrototype_ = des.read<bool>();
+      name_ = des.read<UniqueString>();
+    }
+
+
   bool contentsMatchInner(const AstNode* other) const override {
     const Include* lhs = this;
     const Include* rhs = other->toInclude();
@@ -100,6 +108,16 @@ class Include final : public AstNode {
   UniqueString name() const {
     return name_;
   }
+
+  void serialize(Serializer& ser) const override {
+    AstNode::serializePart(ser);
+    ser(visibility_);
+    ser(isPrototype_);
+    ser(name_);
+  }
+
+  DECLARE_STATIC_DES(Include);
+
 };
 
 

--- a/frontend/include/chpl/uast/Interface.h
+++ b/frontend/include/chpl/uast/Interface.h
@@ -75,6 +75,15 @@ class Interface final : public NamedDecl {
     // TODO: Some assertions here...
   }
 
+  Interface(Deserializer& des)
+    : NamedDecl(asttags::Interface, des) {
+      interfaceFormalsChildNum_ = des.read<int>();
+      numInterfaceFormals_ = des.read<int>();
+      bodyChildNum_ = des.read<int>();
+      numBodyStmts_ = des.read<int>();
+      isFormalListExplicit_ = des.read<bool>();
+    }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const Interface* lhs = this;
     const Interface* rhs = (const Interface*) other;
@@ -183,6 +192,18 @@ class Interface final : public NamedDecl {
                                 bool isFormalListExplicit,
                                 AstList formals,
                                 AstList body);
+
+  void serialize(Serializer& ser) const override {
+    NamedDecl::serializePart(ser);
+    ser(interfaceFormalsChildNum_);
+    ser(numInterfaceFormals_);
+    ser(bodyChildNum_);
+    ser(numBodyStmts_);
+    ser(isFormalListExplicit_);
+  }
+
+  DECLARE_STATIC_DES(Interface);
+
 };
 
 

--- a/frontend/include/chpl/uast/Label.h
+++ b/frontend/include/chpl/uast/Label.h
@@ -50,6 +50,11 @@ class Label final : public AstNode {
     assert(numChildren() == 1);
   }
 
+  Label(Deserializer& des)
+    : AstNode(asttags::Label, des) {
+      name_ = des.read<UniqueString>();
+    }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const Label* lhs = this;
     const Label* rhs = other->toLabel();
@@ -94,6 +99,14 @@ class Label final : public AstNode {
   UniqueString name() const {
     return name_;
   }
+
+  void serialize(Serializer& ser) const override {
+    AstNode::serializePart(ser);
+    ser(name_);
+  }
+
+  DECLARE_STATIC_DES(Label);
+
 
 };
 

--- a/frontend/include/chpl/uast/Let.h
+++ b/frontend/include/chpl/uast/Let.h
@@ -51,6 +51,11 @@ class Let final : public AstNode {
     assert(1 <= numDecls && (numDecls == numChildren() - 1));
   }
 
+  Let(Deserializer& des)
+    : AstNode(asttags::Let, des) {
+      numDecls_ = des.read<int>();
+    }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const Let* lhs = this;
     const Let* rhs = other->toLet();
@@ -104,6 +109,13 @@ class Let final : public AstNode {
     assert(ret);
     return ret;
   }
+
+  void serialize(Serializer& ser) const override {
+    AstNode::serializePart(ser);
+    ser(numDecls_);
+  }
+
+  DECLARE_STATIC_DES(Let);
 
 };
 

--- a/frontend/include/chpl/uast/Local.h
+++ b/frontend/include/chpl/uast/Local.h
@@ -59,6 +59,11 @@ class Local final : public SimpleBlockLike {
       condChildNum_(condChildNum) {
   }
 
+  Local(Deserializer& des)
+    : SimpleBlockLike(asttags::Local, des) {
+    condChildNum_ = des.read<int8_t>();
+  }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const Local* lhs = this;
     const Local* rhs = (const Local*) other;
@@ -104,6 +109,13 @@ class Local final : public SimpleBlockLike {
   const AstNode* condition() const {
     return condChildNum_ < 0 ? nullptr : child(condChildNum_);
   }
+
+  void serialize(Serializer& ser) const override {
+    SimpleBlockLike::serializePart(ser);
+    ser(condChildNum_);
+  }
+
+  DECLARE_STATIC_DES(Local);
 
 };
 

--- a/frontend/include/chpl/uast/Manage.h
+++ b/frontend/include/chpl/uast/Manage.h
@@ -67,6 +67,13 @@ class Manage final : public SimpleBlockLike {
     #endif
   }
 
+  Manage(Deserializer& des)
+    : SimpleBlockLike(asttags::Manage, des) {
+      managerExprChildNum_ = des.read<int>();
+      numManagerExprs_ = des.read<int>();
+    }
+
+
   bool contentsMatchInner(const AstNode* other) const override {
     const Manage* lhs = this;
     const Manage* rhs = (const Manage*) other;
@@ -117,6 +124,15 @@ class Manage final : public SimpleBlockLike {
     auto ret = child(managerExprChildNum_ + i);
     return ret;
   }
+
+  void serialize(Serializer& ser) const override {
+    SimpleBlockLike::serializePart(ser);
+    ser(managerExprChildNum_);
+    ser(numManagerExprs_);
+  }
+
+  DECLARE_STATIC_DES(Manage);
+
 };
 
 

--- a/frontend/include/chpl/uast/New.h
+++ b/frontend/include/chpl/uast/New.h
@@ -68,6 +68,11 @@ class New : public AstNode {
     : AstNode(asttags::New, std::move(children)),
       management_(management) {}
 
+  New(Deserializer& des)
+    : AstNode(asttags::New, des) {
+        management_ = des.read<Management>();
+      }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const New* lhs = this;
     const New* rhs = (const New*) other;
@@ -107,10 +112,20 @@ class New : public AstNode {
     return management_;
   }
 
+  void serialize(Serializer& ser) const override {
+    AstNode::serializePart(ser);
+    ser(management_);
+  }
+
+  DECLARE_STATIC_DES(New);
+
 };
 
 
 } // end namespace uast
+
+DECLARE_SERDE_ENUM(uast::New::Management, uint8_t);
+
 } // end namespace chpl
 
 #endif

--- a/frontend/include/chpl/uast/Reduce.h
+++ b/frontend/include/chpl/uast/Reduce.h
@@ -73,6 +73,9 @@ class Reduce final : public Call {
     assert(numChildren() == 2);
   }
 
+  Reduce(Deserializer& des)
+      : Call(asttags::Reduce, des) { }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const Reduce* rhs = other->toReduce();
     return this->callContentsMatchInner(rhs);
@@ -109,6 +112,12 @@ class Reduce final : public Call {
   const AstNode* iterand() const {
     return this->child(iterandExprChildNum_);
   }
+
+  void serialize(Serializer& ser) const override {
+    Call::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(Reduce);
 
 };
 

--- a/frontend/include/chpl/uast/ReduceIntent.h
+++ b/frontend/include/chpl/uast/ReduceIntent.h
@@ -63,6 +63,9 @@ class ReduceIntent final : public NamedDecl {
     assert(numChildren() == 1);
   }
 
+  ReduceIntent(Deserializer& des)
+    : NamedDecl(asttags::ReduceIntent, des) { }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const ReduceIntent* rhs = other->toReduceIntent();
     return this->namedDeclContentsMatchInner(rhs);
@@ -91,6 +94,12 @@ class ReduceIntent final : public NamedDecl {
   const AstNode* op() const {
     return this->child(opChildNum_);
   }
+
+  void serialize(Serializer& ser) const override {
+    NamedDecl::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(ReduceIntent);
 
 };
 

--- a/frontend/include/chpl/uast/Require.h
+++ b/frontend/include/chpl/uast/Require.h
@@ -44,6 +44,9 @@ class Require final : public AstNode {
     : AstNode(asttags::Require, std::move(children)) {
   }
 
+  Require(Deserializer& des)
+    : AstNode(asttags::Require, des) { }
+
   bool contentsMatchInner(const AstNode* other) const override {
     return true;
   }
@@ -82,6 +85,12 @@ class Require final : public AstNode {
     const AstNode* ast = this->child(i);
     return ast;
   }
+
+  void serialize(Serializer& ser) const override {
+    AstNode::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(Require);
 
 };
 

--- a/frontend/include/chpl/uast/Scan.h
+++ b/frontend/include/chpl/uast/Scan.h
@@ -50,6 +50,9 @@ class Scan final : public Call {
     assert(numChildren() == 2);
   }
 
+  Scan(Deserializer& des)
+    : Call(asttags::Scan, des) { }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const Scan* rhs = other->toScan();
     return this->callContentsMatchInner(rhs);
@@ -82,6 +85,12 @@ class Scan final : public Call {
   const AstNode* iterand() const {
     return this->child(iterandChildNum_);
   }
+
+  void serialize(Serializer& ser) const override {
+    Call::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(Scan);
 
 };
 

--- a/frontend/include/chpl/uast/Select.h
+++ b/frontend/include/chpl/uast/Select.h
@@ -51,6 +51,10 @@ class Select final : public AstNode {
       numWhenStmts_(numWhenStmts) {
   }
 
+  Select(Deserializer& des) : AstNode(asttags::Select, des) {
+    numWhenStmts_ = des.read<int>();
+  }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const Select* rhs = other->toSelect();
     return this->numWhenStmts_ == rhs->numWhenStmts_;
@@ -109,6 +113,13 @@ class Select final : public AstNode {
     auto end = begin + numWhenStmts_;
     return AstListIteratorPair<When>(begin, end);
   }
+
+  void serialize(Serializer& ser) const override {
+    AstNode::serializePart(ser);
+    ser(numWhenStmts_);
+  }
+
+  DECLARE_STATIC_DES(Select);
 
 };
 

--- a/frontend/include/chpl/uast/Serial.h
+++ b/frontend/include/chpl/uast/Serial.h
@@ -59,6 +59,11 @@ class Serial final : public SimpleBlockLike {
       condChildNum_(condChildNum) {
   }
 
+  Serial(Deserializer& des)
+    : SimpleBlockLike(asttags::Serial, des) {
+      condChildNum_ = des.read<int8_t>();
+    }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const Serial* lhs = this;
     const Serial* rhs = (const Serial*) other;
@@ -104,6 +109,13 @@ class Serial final : public SimpleBlockLike {
   const AstNode* condition() const {
     return condChildNum_ < 0 ? nullptr : child(condChildNum_);
   }
+
+  void serialize(Serializer& ser) const override {
+    SimpleBlockLike::serializePart(ser);
+    ser(condChildNum_);
+  }
+
+  DECLARE_STATIC_DES(Serial);
 
 };
 

--- a/frontend/include/chpl/uast/Sync.h
+++ b/frontend/include/chpl/uast/Sync.h
@@ -60,6 +60,9 @@ class Sync final : public SimpleBlockLike {
     assert(bodyChildNum_ >= 0);
   }
 
+  Sync(Deserializer& des)
+    : SimpleBlockLike(asttags::Sync, des) { }
+
   bool contentsMatchInner(const AstNode* other) const override {
     return simpleBlockLikeContentsMatchInner(other);
   }
@@ -77,6 +80,13 @@ class Sync final : public SimpleBlockLike {
   static owned<Sync> build(Builder* builder, Location loc,
                            BlockStyle blockStyle,
                            AstList stmts);
+
+  void serialize(Serializer& ser) const override {
+    SimpleBlockLike::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(Sync);
+
 };
 
 

--- a/frontend/include/chpl/uast/TaskVar.h
+++ b/frontend/include/chpl/uast/TaskVar.h
@@ -73,6 +73,11 @@ class TaskVar final : public VarLikeDecl {
                     initExpressionChildNum) {
   }
 
+  TaskVar(Deserializer& des)
+      : VarLikeDecl(asttags::TaskVar, des) {
+
+  }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const TaskVar* lhs = this;
     const TaskVar* rhs = (const TaskVar*) other;
@@ -99,10 +104,21 @@ class TaskVar final : public VarLikeDecl {
   */
   Intent intent() const { return (Intent)((int)storageKind()); }
 
+  void serialize(Serializer& ser) const override {
+    VarLikeDecl::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(TaskVar);
+
 };
+
+// DECLARE_SERDE_ENUM(uast::TaskVar::Intent, uint8_t);
 
 
 } // end namespace uast
+
+
+
 } // end namespace chpl
 
 #endif

--- a/frontend/include/chpl/uast/Throw.h
+++ b/frontend/include/chpl/uast/Throw.h
@@ -47,6 +47,9 @@ class Throw final : public AstNode {
     assert(numChildren() == 1);
   }
 
+  Throw(Deserializer& des)
+    : AstNode(asttags::Throw, des) { }
+
   bool contentsMatchInner(const AstNode* other) const override {
     return true;
   }
@@ -72,6 +75,12 @@ class Throw final : public AstNode {
     const AstNode* ast = this->child(errorExprChildNum_);
     return ast;
   }
+
+  void serialize(Serializer& ser) {
+    AstNode::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(Throw);
 
 };
 

--- a/frontend/include/chpl/uast/Throw.h
+++ b/frontend/include/chpl/uast/Throw.h
@@ -76,7 +76,7 @@ class Throw final : public AstNode {
     return ast;
   }
 
-  void serialize(Serializer& ser) {
+  void serialize(Serializer& ser) const override {
     AstNode::serializePart(ser);
   }
 

--- a/frontend/include/chpl/uast/Try.h
+++ b/frontend/include/chpl/uast/Try.h
@@ -74,6 +74,14 @@ class Try final : public AstNode {
     }
   }
 
+  Try(Deserializer& des)
+    : AstNode(asttags::Try, des) {
+      numHandlers_ = des.read<int>();
+      containsBlock_ = des.read<bool>();
+      isExpressionLevel_ = des.read<bool>();
+      isTryBang_ = des.read<bool>();
+  }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const Try* rhs = other->toTry();
     return this->numHandlers_ == rhs->numHandlers_ &&
@@ -206,6 +214,16 @@ class Try final : public AstNode {
   bool isTryBang() const {
     return isTryBang_;
   }
+
+  void serialize(Serializer& ser) const override {
+    AstNode::serializePart(ser);
+    ser(numHandlers_);
+    ser(containsBlock_);
+    ser(isExpressionLevel_);
+    ser(isTryBang_);
+  }
+
+  DECLARE_STATIC_DES(Try);
 
 };
 

--- a/frontend/include/chpl/uast/TupleDecl.h
+++ b/frontend/include/chpl/uast/TupleDecl.h
@@ -95,6 +95,14 @@ class TupleDecl final : public Decl {
     assert(assertAcceptableTupleDecl());
   }
 
+  TupleDecl(Deserializer& des)
+    : Decl(asttags::TupleDecl, des) {
+      intentOrKind_ = des.read<IntentOrKind>();
+      numElements_ = des.read<int>();
+      typeExpressionChildNum_ = des.read<int>();
+      initExpressionChildNum_ = des.read<int>();
+    }
+
   bool assertAcceptableTupleDecl();
 
   bool contentsMatchInner(const AstNode* other) const override {
@@ -186,10 +194,26 @@ class TupleDecl final : public Decl {
       return nullptr;
     }
   }
+
+  void serialize(Serializer& ser) const override {
+    Decl::serializePart(ser);
+    ser(intentOrKind_);
+    ser(numElements_);
+    ser(typeExpressionChildNum_);
+    ser(initExpressionChildNum_);
+  }
+
+  DECLARE_STATIC_DES(TupleDecl);
+
 };
 
 
 } // end namespace uast
+
+
+DECLARE_SERDE_ENUM(uast::TupleDecl::IntentOrKind, uint8_t);
+
+
 } // end namespace chpl
 
 #endif

--- a/frontend/include/chpl/uast/Union.h
+++ b/frontend/include/chpl/uast/Union.h
@@ -63,6 +63,10 @@ class Union final : public AggregateDecl {
     assert(linkage != Decl::EXPORT);
   }
 
+  Union(Deserializer& des)
+    : AggregateDecl(asttags::Union, des) { }
+
+
   bool contentsMatchInner(const AstNode* other) const override {
     const Union* lhs = this;
     const Union* rhs = (const Union*) other;
@@ -83,6 +87,13 @@ class Union final : public AggregateDecl {
                             owned<AstNode> linkageName,
                             UniqueString name,
                             AstList contents);
+
+  void serialize(Serializer& ser) const override {
+    AggregateDecl::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(Union);
+
 };
 
 

--- a/frontend/include/chpl/uast/VarArgFormal.h
+++ b/frontend/include/chpl/uast/VarArgFormal.h
@@ -64,6 +64,11 @@ class VarArgFormal final : public VarLikeDecl {
       countChildNum_(countChildNum) {
   }
 
+  VarArgFormal(Deserializer& des)
+    : VarLikeDecl(asttags::VarArgFormal, des) {
+      countChildNum_ = des.read<int>();
+    }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const VarArgFormal* lhs = this;
     const VarArgFormal* rhs = (const VarArgFormal*) other;
@@ -105,6 +110,13 @@ class VarArgFormal final : public VarLikeDecl {
     auto ret = child(countChildNum_);
     return ret;
   }
+
+  void serialize(Serializer& ser) const override {
+    VarLikeDecl::serializePart(ser);
+    ser(countChildNum_);
+  }
+
+  DECLARE_STATIC_DES(VarArgFormal);
 
 };
 

--- a/frontend/include/chpl/uast/When.h
+++ b/frontend/include/chpl/uast/When.h
@@ -44,6 +44,11 @@ class When final : public SimpleBlockLike {
       numCaseExprs_(numCaseExprs) {
   }
 
+  When(Deserializer& des)
+    : SimpleBlockLike(asttags::When, des) {
+      numCaseExprs_ = des.read<int>();
+    }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const When* rhs = other->toWhen();
     return this->numCaseExprs_ == rhs->numCaseExprs_ &&
@@ -102,6 +107,13 @@ class When final : public SimpleBlockLike {
   bool isOtherwise() const {
     return numCaseExprs_ == 0;
   }
+
+  void serialize(Serializer& ser) const override {
+    SimpleBlockLike::serializePart(ser);
+    ser(numCaseExprs_);
+  }
+
+  DECLARE_STATIC_DES(When);
 
 };
 

--- a/frontend/include/chpl/uast/WithClause.h
+++ b/frontend/include/chpl/uast/WithClause.h
@@ -49,6 +49,9 @@ class WithClause final : public AstNode {
     : AstNode(asttags::WithClause, std::move(exprs)) {
   }
 
+  WithClause(Deserializer& des)
+    : AstNode(asttags::WithClause, des) { }
+
   bool contentsMatchInner(const AstNode* other) const override {
     return true;
   }
@@ -86,6 +89,13 @@ class WithClause final : public AstNode {
     const AstNode* ast = this->child(i);
     return ast;
   }
+
+  void serialize(Serializer& ser) const override {
+    AstNode::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(WithClause);
+
 };
 
 

--- a/frontend/include/chpl/uast/Yield.h
+++ b/frontend/include/chpl/uast/Yield.h
@@ -48,6 +48,10 @@ class Yield final : public AstNode {
     assert(children_.size() == 1);
   }
 
+  Yield(Deserializer& des)
+    : AstNode(asttags::Yield, des) {
+  }
+
   bool contentsMatchInner(const AstNode* other) const override {
     // The 'valueChildNum_' is const and does not need to be compared.
     return true;
@@ -76,6 +80,12 @@ class Yield final : public AstNode {
     assert(ret);
     return ret;
   }
+
+  void serialize(Serializer& ser) const override {
+    AstNode::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(Yield);
 
 };
 

--- a/frontend/include/chpl/uast/Zip.h
+++ b/frontend/include/chpl/uast/Zip.h
@@ -37,6 +37,9 @@ class Zip final : public Call {
            /*hasCalledExpression*/ false) {
   }
 
+  Zip(Deserializer& des)
+    : Call(asttags::Zip, des) { }
+
   bool contentsMatchInner(const AstNode* other) const override {
     return callContentsMatchInner(other->toCall());
   }
@@ -52,6 +55,12 @@ class Zip final : public Call {
     Create and return a zip expression.
   */
   static owned<Zip> build(Builder* builder, Location loc, AstList actuals);
+
+  void serialize(Serializer& ser) const override {
+    Call::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(Zip);
 
 };
 

--- a/frontend/include/chpl/uast/uast-classes-list.h
+++ b/frontend/include/chpl/uast/uast-classes-list.h
@@ -72,7 +72,6 @@
   AST_NODE(Require)                    //
   AST_NODE(Return)                     //
   AST_NODE(Select)                     //
-  AST_NODE(Sync)                       //
   AST_NODE(Throw)                      //
   AST_NODE(Try)                        // old AST: TryStmt
   AST_NODE(TypeQuery)                  //
@@ -89,6 +88,7 @@
     AST_NODE(Manage)                   //
     AST_NODE(On)                       //
     AST_NODE(Serial)                   //
+    AST_NODE(Sync)                       //
     AST_NODE(When)                     //
   AST_END_SUBCLASSES(SimpleBlockLike)
 

--- a/frontend/lib/uast/BuilderResult.cpp
+++ b/frontend/lib/uast/BuilderResult.cpp
@@ -272,7 +272,7 @@ AstList BuilderResult::deserializeFromFile(Context* context, std::istream& is) {
 
 bool BuilderResult::compare(const AstList& other) const {
   const int n = numTopLevelExpressions();
-  if (other.size() != n) {
+  if (other.size() != (size_t)n) {
     return false;
   }
   for (int i = 0; i < n; i++) {

--- a/frontend/lib/uast/BuilderResult.cpp
+++ b/frontend/lib/uast/BuilderResult.cpp
@@ -255,6 +255,8 @@ AstList BuilderResult::deserializeFromFile(Context* context, std::istream& is) {
 
   auto m = des.read<uint64_t>();
   auto v = des.read<uint32_t>();
+  (void)m; // silence unused variable warnings
+  (void)v; // silence unused variable warnings
   assert(m == magic);
   assert(v == version);
 

--- a/util/chpl-completion.bash
+++ b/util/chpl-completion.bash
@@ -63,6 +63,8 @@ _chpl ()
 --dyno-debug-trace \
 --dyno-scope-bundled \
 --dyno-scope-production \
+--dyno-serialize \
+--dyno-serialize-dir \
 --early-deinit \
 --explain-call \
 --explain-call-id \
@@ -177,6 +179,7 @@ _chpl ()
 --no-dyno-debug-trace \
 --no-dyno-scope-bundled \
 --no-dyno-scope-production \
+--no-dyno-serialize \
 --no-early-deinit \
 --no-explain-verbose \
 --no-fast-followers \


### PR DESCRIPTION
This PR implements the serialize/deserialize methods for the remaining uAST nodes.


TESTING:

- [x] paratest (0 failures)