### PR TITLE
Add prediffs to test to avoid them breaking for changing hashes

### DIFF
--- a/test/types/cptr/const/const_actual_nonconst_formal.good
+++ b/test/types/cptr/const/const_actual_nonconst_formal.good
@@ -1,4 +1,4 @@
-internal error: UTI-MIS-1049 chpl version 2.7.0 pre-release (de786db05f4)
+internal error: UTI-MIS-nnnn chpl version mmmm
 
 Internal errors indicate a bug in the Chapel compiler,
 and we're sorry for the hassle.  We would appreciate your reporting this bug --

--- a/test/types/cptr/const/const_actual_nonconst_formal.prediff
+++ b/test/types/cptr/const/const_actual_nonconst_formal.prediff
@@ -1,0 +1,1 @@
+../../../../util/test/prediff-obscure-internal-error

--- a/test/types/partial/multiple-question.good
+++ b/test/types/partial/multiple-question.good
@@ -1,4 +1,4 @@
-internal error: UTI-MIS-1049 chpl version 2.7.0 pre-release (de786db05f4)
+internal error: UTI-MIS-nnnn chpl version mmmm
 
 Internal errors indicate a bug in the Chapel compiler,
 and we're sorry for the hassle.  We would appreciate your reporting this bug --

--- a/test/types/partial/multiple-question.prediff
+++ b/test/types/partial/multiple-question.prediff
@@ -1,0 +1,1 @@
+../../../util/test/prediff-obscure-internal-error

--- a/test/types/typedefs/bradc/redefineTypeNames3.good
+++ b/test/types/typedefs/bradc/redefineTypeNames3.good
@@ -1,4 +1,4 @@
-internal error: UTI-MIS-1049 chpl version 2.7.0 pre-release (de786db05f4)
+internal error: UTI-MIS-nnnn chpl version mmmm
 
 Internal errors indicate a bug in the Chapel compiler,
 and we're sorry for the hassle.  We would appreciate your reporting this bug --

--- a/test/types/typedefs/bradc/redefineTypeNames3.prediff
+++ b/test/types/typedefs/bradc/redefineTypeNames3.prediff
@@ -1,0 +1,1 @@
+../../../../util/test/prediff-obscure-internal-error

--- a/util/test/prediff-obscure-internal-error
+++ b/util/test/prediff-obscure-internal-error
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#
+# Designed to squash out internal error codes from tests that lock down internal
+# errors, which are sensitive to code locations and commit hashes. The `sed`
+# command is borrowed from:
+#
+# `util/test/diff-ignoring-module-line-numbers`
+#
+
+tmpfile=$2
+
+tmptmp=`mktemp "tmp.XXXXXX"`
+
+regex='
+    s/chpl version [0-9]*.*$/chpl version mmmm/
+    s/internal error: \([A-Z][A-Z\-]*\)[0-9][0-9]* chpl version mmmm/internal error: \1nnnn chpl version mmmm/
+'
+
+sed -e "$regex" $tmpfile > $tmptmp
+
+mv $tmptmp $tmpfile


### PR DESCRIPTION
These tests lock down an internal error, but the wording of the internal error is relative to the current HEAD commit. Thus, the tests break with each commit. This PR adds a prediff to these to avoid this issue.